### PR TITLE
Allow non-Latin characters in URLs

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
         var hash = location.hash.slice(1).trim();
         try {
           var decoded = atob(hash);
-          if(decoded.startsWith("!"))
+          if (decoded.startsWith("!"))
             decoded = decodeURIComponent(decoded.substr(1));
           if (decoded.length < 1) {
             document.write('No redirect passed - sending you to the make page: ');

--- a/index.html
+++ b/index.html
@@ -21,6 +21,8 @@
         var hash = location.hash.slice(1).trim();
         try {
           var decoded = atob(hash);
+          if(decoded.startsWith("!"))
+            decoded = decodeURIComponent(decoded.substr(1));
           if (decoded.length < 1) {
             document.write('No redirect passed - sending you to the make page: ');
             makea('http://redirectatob.github.io/make.html');

--- a/make.html
+++ b/make.html
@@ -19,7 +19,13 @@
     </div>
     <script>
       function update() {
-        var u = 'http://redirectatob.github.io/index.html#' + btoa(document.getElementById('url').value);
+        var u = 'http://redirectatob.github.io/index.html#';
+        var r = document.getElementById('url').value;
+        try {
+          u += btoa(r)
+        } catch (e) {
+          u += btoa("!" + encodeURIComponent(r))
+        }
         var a = document.querySelector('a');
         a.href = u;
         a.innerText = u;

--- a/make.html
+++ b/make.html
@@ -22,9 +22,9 @@
         var u = 'http://redirectatob.github.io/index.html#';
         var r = document.getElementById('url').value;
         try {
-          u += btoa(r)
+          u += btoa(r);
         } catch (e) {
-          u += btoa("!" + encodeURIComponent(r))
+          u += btoa("!" + encodeURIComponent(r));
         }
         var a = document.querySelector('a');
         a.href = u;


### PR DESCRIPTION
This pull request fixes #1 

I described the method I used in the issue; but to quickly summarise, here's how it goes:

## Encoding

- If the URL can be `btoa`ed, then it is
- If it can't, then it's `encodeURIComponent`ed, and a flag is placed in front of it (`!`) first, then `btoa`ed

## Decoding

- The URL is `atob`ed
- If the decoded version contains the flag, then that flag is stripped and the rest is `decodeURIComponent`ed

This pull request has _not_ been tested and requires heavy testing

## Known issues

If you try and encode a URL that starts with a `!` (like `!https://example.com`); then unexpected things may happen (for example, if the URL contains encoded components -- those will be decoded before redirection).

However, I don't think this is a problem because before, this would fail the security checks. Now, it will do potentially unexpected things. I think it's the responsibility of the person doing the encoding that they enter a valid URL.