### PR TITLE
Change protocol match to be much simpler; support data:… URLs

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,13 +27,8 @@
             location.replace('http://redirectatob.github.io/make.html');
             return;
           }
-          var protocol = decoded.match(/^([a-zA-Z]+)?:\/\//);
-          if (!protocol) {
-            document.write('No protocol specified.');
-            return;
-          }
-          protocol = protocol[1];
-          if (!['data', 'http', 'https'].includes(protocol.toLowerCase())) {
+          var protocol = decoded.match();
+          if (!/^((http|https):\/\/|data:)/.test(decoded)) {
             document.write('Invalid protocol specified.');
             return;
           }


### PR DESCRIPTION
This changes the regex to simply be a test, which now directly includes checking if the protocol is either `http` or `https` (and also checks if the string simply starts with `data:`).

This makes `data:` URLs work (try `data:text/plain,Hello` / location hash `#ZGF0YTp0ZXh0L3BsYWluLGhp`). It also should improve support for older browsers, since it doesn't rely on `Array.prototype.includes`, which is [not supported](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes#Browser_compatibility) in IE or relatively old versions of other browsers (it's part of ES2016).

Ping @joker314 for review.