### PR TITLE
Don't use startsWith, which isn't supported on Internet Explorer

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
         var hash = location.hash.slice(1).trim();
         try {
           var decoded = atob(hash);
-          if (decoded.startsWith("!"))
+          if (decoded[0] === '!')
             decoded = decodeURIComponent(decoded.substr(1));
           if (decoded.length < 1) {
             document.write('No redirect passed - sending you to the make page: ');


### PR DESCRIPTION
Instead just use `[0] === '!'` (since we're only testing for a single character).
