### PR TITLE
Default to generic sans-serif if Helvetica font isn't available

### DIFF
--- a/make.css
+++ b/make.css
@@ -19,7 +19,7 @@ body {
   background: white;
   max-width: 600px;
   padding: 40px;
-  font-family: "Helvetica";
+  font-family: "Helvetica", sans-serif;
   line-height: 1.8em;
   box-sizing: border-box;
   box-shadow: 0 3px 0 #888888;


### PR DESCRIPTION
I honestly don't know how I didn't think to do this when I first wrote this project.

Before (browser default font):

![Top of the make page, with the default browser font, a serif](https://user-images.githubusercontent.com/9948030/45596977-1220a980-b99b-11e8-998e-71f112c2b249.png)

After (sans-serif):

![Top of the make page, with the generic sans-serif font](https://user-images.githubusercontent.com/9948030/45596978-1cdb3e80-b99b-11e8-909b-bf6608cb2a1c.png)
