### PR TITLE
Validate upon encoding (rather than solely on decoding)

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
             return;
           }
           var protocol = decoded.match();
-          if (!/^((http|https):\/\/|data:)/.test(decoded)) {
+          if (!/^((https?:\/\/|data:)/i.test(decoded)) {
             document.write('Invalid protocol specified.');
             return;
           }

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
             return;
           }
           var protocol = decoded.match();
-          if (!/^((https?:\/\/|data:)/i.test(decoded)) {
+          if (!/^(https?:\/\/|data:)/i.test(decoded)) {
             document.write('Invalid protocol specified.');
             return;
           }

--- a/make.css
+++ b/make.css
@@ -38,3 +38,7 @@ h1 {
   box-sizing: border-box;
   display: block;
 }
+
+#error {
+  color: red; 
+}

--- a/make.html
+++ b/make.html
@@ -11,7 +11,8 @@
       <p>Redirectatobs only work for people who have JavaScript! So you should probably only be giving these URLs to your hacker friends.</p>
       <form id="form">
         <input type="url" title="You can only use http://, https://, and data:" placeholder="URL" id="url" pattern="^((http|https)://|data:).*">
-        <a href="#"></a>
+	<div id="error"></div>
+	<a href="#"></a>
       </form>
       <h2>What is redirectatob?</h2>
       <p>Maybe it'll help if you think of them instead of redirect<code>atob</code>s. Basically, redirectatob is a webpage that you pass a URL to in the location hash (i.e. domain/page.html<b>#hash</b>, but encoded with <code>btoa</code>. The webpage will convert the encoded hash back into a URL using <code>atob</code> through the client's JavaScript. I made it so that I could give this URL - <a href="http://www.woodus.com/den/games/dq4ds/mugshots.php">http://www.woodus.com/den/games/dq4ds/mugshots.php</a> - to a friend of mine. The site's blacklist was preventing me from posting the link, and, as it had happened to me multiple times before, I decided I needed to make a redirect service.</p>
@@ -21,6 +22,17 @@
       function update() {
         var u = 'https://redirectatob.github.io/index.html#';
         var r = document.getElementById('url').value;
+
+        // All modern browsers support the pattern attribute, but just in case:
+        if (r && !/^((http|https):\/\/|data:)/.test(r)) {
+          document.getElementById('error').innerText = 'You can only use http://, https://, and data:'
+          document.getElementById('url').innerText = ''
+
+          return 
+	} else {
+          document.getElementById('error').innerText = ''
+        }
+
         try {
           u += btoa(r);
         } catch (e) {

--- a/make.html
+++ b/make.html
@@ -12,7 +12,7 @@
       <form id="form">
         <input type="url" title="You can only use http://, https://, and data:" placeholder="URL" id="url" pattern="^([hH][tT][tT][pP][sS]?://|[dD][aA][tT][aA]:).*">
         <div id="error"></div>
-        <a href="#"></a>
+        <a id="output" href="#"></a>
       </form>
       <h2>What is redirectatob?</h2>
       <p>Maybe it'll help if you think of them instead of redirect<code>atob</code>s. Basically, redirectatob is a webpage that you pass a URL to in the location hash (i.e. domain/page.html<b>#hash</b>, but encoded with <code>btoa</code>. The webpage will convert the encoded hash back into a URL using <code>atob</code> through the client's JavaScript. I made it so that I could give this URL - <a href="http://www.woodus.com/den/games/dq4ds/mugshots.php">http://www.woodus.com/den/games/dq4ds/mugshots.php</a> - to a friend of mine. The site's blacklist was preventing me from posting the link, and, as it had happened to me multiple times before, I decided I needed to make a redirect service.</p>
@@ -20,25 +20,24 @@
     </div>
     <script>
       function update() {
+        var a = document.getElementById('output');
         var u = 'https://redirectatob.github.io/index.html#';
         var r = document.getElementById('url').value;
 
+
         // All modern browsers support the pattern attribute, but just in case:
         if (r && !/^(https?:\/\/|data:)/i.test(r)) {
-          document.getElementById('error').innerText = 'You can only use http://, https://, and data:'
-          document.querySelector('a').innerText = ''
-
-          return 
-        } else {
-          document.getElementById('error').innerText = ''
+          document.getElementById('error').innerText = 'You can only use http://, https://, and data:';
+          document.querySelector('a').innerText = '';
+          return;
         }
+        document.getElementById('error').innerText = '';
 
         try {
           u += btoa(r);
         } catch (e) {
           u += btoa("!" + encodeURIComponent(r));
         }
-        var a = document.querySelector('a');
         a.href = u;
         a.style.wordWrap = 'break-word';
         a.innerText = u;

--- a/make.html
+++ b/make.html
@@ -10,7 +10,7 @@
       <h1>Make a redirectatob</h1>
       <p>Redirectatobs only work for people who have JavaScript! So you should probably only be giving these URLs to your hacker friends.</p>
       <form id="form">
-        <input type="url" title="You can only use http://, https://, and data:" placeholder="URL" id="url" pattern="^((http|https)://|data:).*">
+        <input type="url" title="You can only use http://, https://, and data:" placeholder="URL" id="url" pattern="^([hH][tT][tT][pP][sS]?://|[dD][aA][tT][aA]:).*">
 	<div id="error"></div>
 	<a href="#"></a>
       </form>
@@ -24,7 +24,7 @@
         var r = document.getElementById('url').value;
 
         // All modern browsers support the pattern attribute, but just in case:
-        if (r && !/^((http|https):\/\/|data:)/.test(r)) {
+        if (r && !/^((http|https):\/\/|data:)/i.test(r)) {
           document.getElementById('error').innerText = 'You can only use http://, https://, and data:'
           document.getElementById('url').innerText = ''
 

--- a/make.html
+++ b/make.html
@@ -26,7 +26,7 @@
         // All modern browsers support the pattern attribute, but just in case:
         if (r && !/^((http|https):\/\/|data:)/i.test(r)) {
           document.getElementById('error').innerText = 'You can only use http://, https://, and data:'
-          document.getElementById('url').innerText = ''
+          document.querySelector('a').innerText = ''
 
           return 
 	} else {

--- a/make.html
+++ b/make.html
@@ -24,7 +24,7 @@
         var r = document.getElementById('url').value;
 
         // All modern browsers support the pattern attribute, but just in case:
-        if (r && !/^((http|https):\/\/|data:)/i.test(r)) {
+        if (r && !/^(https?:\/\/|data:)/i.test(r)) {
           document.getElementById('error').innerText = 'You can only use http://, https://, and data:'
           document.querySelector('a').innerText = ''
 

--- a/make.html
+++ b/make.html
@@ -11,8 +11,8 @@
       <p>Redirectatobs only work for people who have JavaScript! So you should probably only be giving these URLs to your hacker friends.</p>
       <form id="form">
         <input type="url" title="You can only use http://, https://, and data:" placeholder="URL" id="url" pattern="^([hH][tT][tT][pP][sS]?://|[dD][aA][tT][aA]:).*">
-	<div id="error"></div>
-	<a href="#"></a>
+        <div id="error"></div>
+        <a href="#"></a>
       </form>
       <h2>What is redirectatob?</h2>
       <p>Maybe it'll help if you think of them instead of redirect<code>atob</code>s. Basically, redirectatob is a webpage that you pass a URL to in the location hash (i.e. domain/page.html<b>#hash</b>, but encoded with <code>btoa</code>. The webpage will convert the encoded hash back into a URL using <code>atob</code> through the client's JavaScript. I made it so that I could give this URL - <a href="http://www.woodus.com/den/games/dq4ds/mugshots.php">http://www.woodus.com/den/games/dq4ds/mugshots.php</a> - to a friend of mine. The site's blacklist was preventing me from posting the link, and, as it had happened to me multiple times before, I decided I needed to make a redirect service.</p>
@@ -29,7 +29,7 @@
           document.querySelector('a').innerText = ''
 
           return 
-	} else {
+        } else {
           document.getElementById('error').innerText = ''
         }
 

--- a/make.html
+++ b/make.html
@@ -10,7 +10,7 @@
       <h1>Make a redirectatob</h1>
       <p>Redirectatobs only work for people who have JavaScript! So you should probably only be giving these URLs to your hacker friends.</p>
       <form id="form">
-        <input type="url" placeholder="URL" id="url">
+        <input type="url" title="You can only use http://, https://, and data:" placeholder="URL" id="url" pattern="^((http|https)://|data:).*">
         <a href="#"></a>
       </form>
       <h2>What is redirectatob?</h2>

--- a/make.html
+++ b/make.html
@@ -36,7 +36,7 @@
         try {
           u += btoa(r);
         } catch (e) {
-          u += btoa("!" + encodeURIComponent(r));
+          u += btoa('!' + encodeURIComponent(r));
         }
         a.href = u;
         a.style.wordWrap = 'break-word';


### PR DESCRIPTION
Resolves #20 

In that issue, it was expected that Opera did not support pattern matching. Surprise!!

![Screenshot of validation error](https://user-images.githubusercontent.com/18113170/45602430-176f0a00-ba16-11e8-82e6-88a9a8305f34.png)

However, I believe a different related browser doesn't support it (maybe the mobile version or something). Therefore, I still included a little JavaScript.

In addition, this pull request does some other things
- Allows uppercase schemes to not fail the validation checks
- Refactors the regular expressions to change `http|https` to `https?`. Perhaps this may impact readability?

Here's a screenshot of the fallback validation:

![](https://user-images.githubusercontent.com/18113170/45602504-6cf7e680-ba17-11e8-8b85-fe50783cb02d.png)

I don't believe there's a way the unicode URIs could stop working because of this change, the regular expression is in unicode mode (irrelevant), and the surrogate pairs that would make it up should be matched by `.` maybe.

> (But don't explicitly check if the browser is Opera.)

Absolutely.

> For one, if popup windows/tabs are disabled (and 99% of the time they are), would this still work?

Good point, the answer is very probably no.